### PR TITLE
Debian Python updates.

### DIFF
--- a/installers/debian/control
+++ b/installers/debian/control
@@ -3,8 +3,8 @@ Section: libs
 Priority: optional
 Maintainer: Manu Sporny <msporny@digitalbazaar.com>
 Homepage: http://rdfa.digitalbazaar.com/librdfa/
-Build-Depends: python-all-dev, libxml2-dev, python-central (>= 0.4.10), dh-buildinfo, debhelper (>= 7.0.0), swig
-XS-Python-Version: all
+Build-Depends: python-all-dev (>= 2.6.6-3~), libxml2-dev, dh-buildinfo, debhelper (>= 7.0.50), swig
+X-Python-Version: 2.7
 Standards-Version: 3.9.1
 
 Package: librdfa1
@@ -34,9 +34,8 @@ Description: RDFa parsing C library - development kit
 Package: python-rdfa
 Architecture: any
 Section: python
-Depends: ${shlibs:Depends}, ${python:Depends}, librdfa1 (= ${binary:Version})
+Depends: ${shlibs:Depends}, ${python:Depends}, ${misc:Depends}, librdfa1 (= ${binary:Version})
 Provides: ${python:Provides}
-XB-Python-Version: ${python:Versions}
 Description: RDFa parsing Python library (Python bindings)
  The librdfa parser is used to extract RDF triples from XHTML+RDFa documents.
  It uses libxml2 for the underlying XML parser, is very small in size (19KB),

--- a/installers/debian/python-rdfa.install
+++ b/installers/debian/python-rdfa.install
@@ -1,1 +1,2 @@
-usr/lib/python*
+usr/lib/python*/*/*.so
+usr/lib/python*/*/*.py

--- a/installers/debian/rules
+++ b/installers/debian/rules
@@ -1,15 +1,12 @@
 #!/usr/bin/make -f
 
-PY_VERSIONS = $(shell pyversions --requested -vs)
+# TODO: Add multi-version and python3 support.
+# http://wiki.debian.org/Python/LibraryStyleGuide
+
+#DH_VERBOSE=1
 
 %:
-	dh $@ --with python-central
+	dh $@ --with python2
 
 override_dh_auto_configure:
 	dh_auto_configure -- --enable-python
-
-override_dh_auto_install:
-	dh_auto_install -- PY_VERSIONS="$(PY_VERSIONS)"
-
-override_dh_pycentral:
-	dh_pycentral -p python-rdfa

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -2,7 +2,7 @@
 
 if BUILD_PYTHON
 
-pythonsitedir = $(libdir)/python/dist-packages
+pythonsitedir = $(PYTHON_SITE_PKG)
 
 dist_pythonsite_DATA = rdfa.py
 
@@ -14,12 +14,13 @@ _rdfa_la_SOURCES = \
 	SwigRdfaParser.cpp
 
 BUILT_SOURCES = SwigRdfaParser.cpp
+CLEANFILES = $(BUILT_SOURCES)
 
 _rdfa_la_LIBADD = $(top_builddir)/c/librdfa.la
 
 AM_CPPFLAGS = \
 	-I$(top_srcdir)/c \
-	$(PYTHON_CPPFLAGS) \
+	$(AX_SWIG_PYTHON_CPPFLAGS) \
 	$(LIBXML2_CFLAGS)
 
 AM_LDFLAGS = -avoid-version -export-dynamic -module

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,4 @@ LDADD = \
 
 EXTRA_DIST = test-cases/fetch-tests
 
-clean-local:
-	rm $(noinst_PROGRAMS)
-
 ## end librdfa/tests/Makefile.am


### PR DESCRIPTION
Some partial Debian Python fixes.  Tied to just build for Python 2.7 for now.  Conversion to build multiple versions at once was more difficult than expected.
